### PR TITLE
24.09.27 프로그래머스 문제 풀이

### DIFF
--- a/Programmers/LV2_더맵게.cpp
+++ b/Programmers/LV2_더맵게.cpp
@@ -1,0 +1,26 @@
+#include <string>
+#include <vector>
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+// 6:46 - 7:02
+
+int solution(vector<int> scoville, int K) {
+    int answer = 0;
+    priority_queue<int, vector<int>, greater<int>> pq;
+    for(int sc : scoville) pq.push(sc);
+    
+    while(pq.size() >= 2 && pq.top() < K) {
+        int first = pq.top(); pq.pop();
+        int second = pq.top(); pq.pop();
+        
+        pq.push(first + second * 2);
+        answer++;
+    }
+    
+    if(pq.top() < K) return -1;
+    
+    return answer;
+}

--- a/Programmers/LV2_뒤에_있는_큰수.cpp
+++ b/Programmers/LV2_뒤에_있는_큰수.cpp
@@ -1,0 +1,34 @@
+#include <string>
+#include <vector>
+#include <stack>
+
+using namespace std;
+
+vector<int> solution(vector<int> numbers) {
+    vector<int> answer(numbers.size());
+    stack<pair<int, int>> st;
+    
+    for(int i = 0; i < numbers.size(); i++) {
+        int num = numbers[i];
+        if(st.empty() || st.top().first > num) {
+            st.push(make_pair(num, i));
+        }
+        else {
+            while(!st.empty() && st.top().first < num) {
+                int value = st.top().first;
+                int index = st.top().second;
+                st.pop();
+                answer[index] = num;
+            }
+            st.push(make_pair(num, i));
+        }
+    }
+    
+    while(!st.empty()) {
+        int val = st.top().first;
+        int idx = st.top().second;
+        st.pop();
+        answer[idx] = -1;
+    }
+    return answer;
+}

--- a/Programmers/LV2_땅따먹기.cpp
+++ b/Programmers/LV2_땅따먹기.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <vector>
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+// 8:27 - 8:50
+
+int find_max(int a, int b, int c) {
+    priority_queue<int> pq;
+    pq.push(a); pq.push(b); pq.push(c);
+    
+    return pq.top();
+}
+
+int solution(vector<vector<int>> land) {
+    int answer = 0;
+    vector<vector<int>> dp(land.size(), vector<int>(4, 0));
+
+    for(int i = 0; i < 4; i++) dp[0][i] = land[0][i];
+        
+    
+    for(int i = 1; i < land.size(); i++) {
+        dp[i][0] = find_max(dp[i - 1][1], dp[i - 1][2], dp[i - 1][3]) + land[i][0];
+        dp[i][1] = find_max(dp[i - 1][0], dp[i - 1][2], dp[i - 1][3]) + land[i][1];
+        dp[i][2] = find_max(dp[i - 1][0], dp[i - 1][1], dp[i - 1][3]) + land[i][2];
+        dp[i][3] = find_max(dp[i - 1][0], dp[i - 1][1], dp[i - 1][2]) + land[i][3];
+    }
+    
+    for(int i = 0; i < 4; i++)
+        if(dp[land.size() - 1][i] > answer) answer = dp[land.size() - 1][i];
+            
+    return answer;
+}

--- a/Programmers/LV2_스킬트리.cpp
+++ b/Programmers/LV2_스킬트리.cpp
@@ -1,0 +1,42 @@
+#include <string>
+#include <vector>
+#include <bits/stdc++.h>
+
+using namespace std;
+
+// 9:05 - 9:39
+
+int solution(string skill, vector<string> skill_trees) {
+    int answer = 0;
+    map<char, int> temporary;
+    map<char, int> count; // 스킬, 선행해야 하는 스킬 수
+    vector<vector<char>> alpha(26); // C 이면 인덱스 2, 다음에 수행할 것들 저장
+    
+    for(int i = 0; i < skill.size(); i++) temporary[skill[i]] = i;
+    for(int i = 0; i < skill.size(); i++) {
+        for(int j = i + 1; j < skill.size(); j++) {
+            alpha[skill[i] - 'A'].push_back(skill[j]);
+        }
+    }
+    
+    for(string st : skill_trees) {
+        int p = 0;
+        count = temporary;
+        bool find = true;
+        while(p < st.size()) {
+            char c = st[p];
+            if(count[c] != 0) { find = false; break; }
+            if(count.find(c) == count.end()) { p++; continue; }
+   
+            count.erase(c); // 0이니까 맵에서 삭제
+            for(int i = 0; i < alpha[c - 'A'].size(); i++) {
+                count[alpha[c - 'A'][i]]--;
+            }
+            p++;
+        }
+        if(find) { answer++; }
+        count.clear();
+    }
+    
+    return answer;
+}

--- a/Programmers/LV2_주식가격.cpp
+++ b/Programmers/LV2_주식가격.cpp
@@ -1,0 +1,34 @@
+#include <string>
+#include <vector>
+#include <iostream>
+#include <stack>
+
+// 7:04 - 7:25
+
+using namespace std;
+
+vector<int> solution(vector<int> prices) {
+    vector<int> answer(prices.size());
+    stack<pair<int, int>> st; 
+    
+    for(int i = 0; i < prices.size(); i++) {
+        int p = prices[i];
+        if(st.empty() || p >= st.top().first) st.push(make_pair(p, i));
+        
+        else {
+            while(!st.empty() && p < st.top().first) {
+                answer[st.top().second] = i - st.top().second;
+                st.pop();
+            }
+            st.push(make_pair(p, i));
+            
+        }    
+    }
+    
+    while(!st.empty()) {
+        answer[st.top().second] = prices.size() - st.top().second - 1;
+        st.pop();
+    }
+    
+    return answer;
+}

--- a/Programmers/LV2_주차요금계산.cpp
+++ b/Programmers/LV2_주차요금계산.cpp
@@ -1,0 +1,59 @@
+#include <string>
+#include <vector>
+#include <bits/stdc++.h>
+#include <sstream>
+
+using namespace std;
+
+// 10:25 - 10:51 
+// 25 + 18 = 43분
+
+int time_to_minute(string t) {
+    string h = t.substr(0, 2);
+    string m = t.substr(3);
+    
+    return stoi(h) * 60 + stoi(m);
+}
+
+int ollim(int a, int b, int c) {
+    if((a - b) % c  == 0) return (a-b)/c;
+    else return (a-b)/c + 1;
+}
+
+vector<int> solution(vector<int> fees, vector<string> records) {
+    vector<int> answer;
+    map<string, int> sumTime;
+    map<string, int> inTime;
+    priority_queue<int> pq;
+    int last = 23 * 60 + 59;
+    
+    // 입차, 출차에 따른 누적 시간 계산
+    for(string re : records) {
+        string time = re.substr(0, 5);
+        string car = re.substr(6, 4);
+        string inout = re.substr(11);
+        
+        if(inout == "IN") inTime[car] = time_to_minute(time);
+        else { 
+            int out = time_to_minute(time); int in = inTime[car];
+            inTime.erase(car);
+            sumTime[car] += out - in;
+        }
+    }
+    
+    for(auto it = inTime.begin(); it != inTime.end(); it++) {
+        string left_car = it->first;
+        int left_in = it->second;
+        sumTime[left_car] += last - left_in;
+        inTime.erase(left_car);
+    }
+    
+    // 주차 요금 계산
+    for(auto it = sumTime.begin(); it != sumTime.end(); it++) {
+        int cost = fees[1] + ollim(it->second, fees[0], fees[2]) * fees[3];
+        if(it->second < fees[0]) cost = fees[1];
+        answer.push_back(cost);
+    }
+    
+    return answer;
+}


### PR DESCRIPTION
## LV2 뒤에 있는 큰 수

numbers를 순회하는데, 일단 스택에 있는 top의 값보다 작거나 같으면 스택에 넣는다. 다음 num이 스택의 top보다 커지면, while을 순회하면서 num보다 작은 값들을 가장 큰 수로 확정한다. 

answer를 무조건 선형적으로 순서대로 구해야 하는 것은 아니다! answer의 사이즈를 정의해두고 배열처럼 num이 큰 값을 확인할 때 확정할 수 있다.

<img width="753" alt="image" src="https://github.com/user-attachments/assets/93ddd555-0979-4d11-b8f0-cc2df74cea8d">

<br>

## LV2 더 맵게

우선순위 큐로 풀어야겠다는 보자마자 한 점은 칭찬! 그러나 2개의 원소가 남았을 때도 스코빌 계산을 할 수 있으므로 등호를 넣어야 한다... 주의하기!

<br>

## LV2 주식가격

뒤에 있는 값들 중에서 큰 값(떨어지지 않는 것)을 세야 했으므로, 오늘 처음 풀었던 뒤에 있는 큰 수 문제와 동일하게 접근했다!! 보자마자 아이디어가 [프로그래머스 LV2 뒤에 있는 큰 수](https://school.programmers.co.kr/learn/courses/30/lessons/154539)와 같음을 깨닫고 바로 적용한 것을 칭찬한다.

<br>

## LV2 땅따먹기
보자마자 백준에서 풀었던 문제와 유사하다고 생각해서, 바로 아이디어를 떠올릴 수 있었다. 근데 문제를 제대로 안읽어서 다시 구현했다 ㅠ_ㅠ [백준 스티커 문제(실버1)](https://www.acmicpc.net/problem/9465)은 3개의 열이어서 두 값만 비교하면 됐지만, 이건 4개의 열이고 본인 열을 제외한 나머지 열을 검사해야 한다. 

세 값 중 최댓값을 구하기 위해 처음에는 if-else로 구현했지만 나중에는 그냥 우선순위 큐를 이용해서 루트에 있는 최댓값을 추출했다. 적절한 자료구조를 잘 생각한 것 같아 뿌듯하다.

<br>

## LV2 스킬트리

[백준 G2 문제집](https://www.acmicpc.net/problem/1766) (모든 문제를 푸는데, 순서가 정해졌고, 가능하면 쉬운 문제부터 풀어야 하는 문제)와 위상정렬 아이디어가 비슷하다고 생각해서 위상정렬처럼 문제를 풀었다. 하지만, 다른 사람의 풀이를 보니 위상정렬처럼 꼭 순서를 줄줄 기억할 필요가 있진 않고, 현재까지 획득한 스킬의 개수와 현재를 읽기위해 필요한 스킬의 수가 일치하는지 확인해서 풀 수 있었다.

즉, A - B - C일 때, 나는 A 뒤에 B, C를 풀어야 함을 (위상정렬 문제처럼) 마킹하면서 체크했는데, 그럴 필요 없는 것 같다!

<br>

## LV2 주차요금 계산

처음에 보자마자 빡구현 문제라고 생각하고 쉽게 방법을 떠올리고, 그대로 구현했다. fee의 순서가 헷갈려서 10분 정도 디버깅하느라 문제를 보자마자부터 맞을 때까지 총 43분의 시간이 걸렸는데, 35분 정도 걸렸으면 좋았겠다 싶다.

### substr
substr에서도 약간 뻘짓을 했다. 

- **`string subs1 = s.substr(2,5)` : 첫번째 인자를 시작 인덱스, 두번째 인자를 갯수라고 생각해서 인덱스 2부터 5개를 읽는다.**
- `string subs1 = s.substr(2)` : 하나만 인자가 있으면 시작 인덱스부터 끝까지 가져온다!
- `string subs1 = s.substr()` : 인자가 하나도 없으면 전체를 가져온다.