### PR TITLE
24.10.02 백준 문제 풀이

### DIFF
--- a/BOJ/G5_15686_re.cpp
+++ b/BOJ/G5_15686_re.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+#include <cmath>
+#include <stdlib.h>
+#define MAX 987654321
+
+using namespace std; // 3:55 - 4:50
+
+int N, M;
+int arr[51][51];
+vector<pair<int, int>> cities; // 1도시들 위치 쌍 기억
+vector<pair<int, int>> chickens; // 2치킨집들 위치 쌍 기억
+int answer = 0; // 구한 쌍에 대해 모든 치킨거리 기억
+vector<int> correct;
+
+int main() {
+    // input
+    cin >> N >> M;
+    for(int i = 0; i < N; i++) {
+        for(int j = 0; j < N; j++) {
+            cin >> arr[i][j];
+            if(arr[i][j] == 1) cities.push_back({i, j});
+            if(arr[i][j] == 2) chickens.push_back({i, j});
+        }
+    }
+
+    // 치킨집들 중에서 M개의 치킨집만 고르기 : 조합, next_permutation
+    vector<pair<int, int>> picked;
+    // 1. 보조 수열 만들기 : M개만큼 0을 넣는다!!!
+    vector<int> tmp(chickens.size(), 1);
+    for(int i = 0; i < M; i++) tmp[i] = 0;
+    
+    // 2. do-while next_permutation
+    do {
+        answer = 0;
+        // picked에 대해서 집과 picked의 치킨 거리 계산
+        // 집 하나 - 모든 치킨거리 구하기 - 최솟값 더하기
+        for(int i = 0; i < cities.size(); i++) {
+            int dist = MAX;
+            for(int j = 0; j < tmp.size(); j++) {
+                if(tmp[j] != 0) continue; 
+                dist = min(dist, abs(cities[i].first - chickens[j].first) + abs(cities[i].second - chickens[j].second));
+            }
+            answer += dist;
+        }
+         
+        correct.push_back(answer);
+        
+    } while(next_permutation(tmp.begin(), tmp.end()));
+
+    sort(correct.begin(), correct.end());
+
+    cout << correct[0];
+    return 0;
+}

--- a/BOJ/G5_15686_re.cpp
+++ b/BOJ/G5_15686_re.cpp
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #define MAX 987654321
 
-using namespace std; // 3:55 - 4:50
+using namespace std; // 3:55
 
 int N, M;
 int arr[51][51];
@@ -33,18 +33,21 @@ int main() {
     
     // 2. do-while next_permutation
     do {
+        picked.clear();
         answer = 0;
+        for(int i = 0; i < tmp.size(); i++) {
+            if(tmp[i] == 0) picked.push_back(chickens[i]);
+        }
+
         // picked에 대해서 집과 picked의 치킨 거리 계산
         // 집 하나 - 모든 치킨거리 구하기 - 최솟값 더하기
         for(int i = 0; i < cities.size(); i++) {
             int dist = MAX;
-            for(int j = 0; j < tmp.size(); j++) {
-                if(tmp[j] != 0) continue; 
-                dist = min(dist, abs(cities[i].first - chickens[j].first) + abs(cities[i].second - chickens[j].second));
+            for(int j = 0; j < picked.size(); j++) {
+                dist = min(dist, abs(cities[i].first - picked[j].first) + abs(cities[i].second - picked[j].second));
             }
             answer += dist;
         }
-         
         correct.push_back(answer);
         
     } while(next_permutation(tmp.begin(), tmp.end()));

--- a/BOJ/G5_7569.cpp
+++ b/BOJ/G5_7569.cpp
@@ -1,83 +1,89 @@
-//#include <iostream>
-//#include <queue>
-//
-//using namespace std;
-//
-//int graph[101][101][101];
-//int visited[101][101][101];
-//
-//int M, N, H;
-//queue<pair<pair<int, int>, int>> q;
-//
-//int dx[] = { 1, -1, 0, 0, 0, 0};
-//int dy[] = { 0, 0, 1, -1, 0, 0};
-//int dz[] = { 0, 0, 0, 0, 1, -1};
-//
-//int answer;
-//
-//int main() {
-//	cin >> M >> N >> H;
-//	int tomato;
-//
-//	for (int k = 1; k <= H; k++) {
-//		for (int i = 1; i <= N; i++) {
-//			for (int j = 1; j <= M; j++) {
-//
-//				cin >> tomato;
-//				graph[i][j][k] = tomato;
-//				if (graph[i][j][k] == 1) { // tomato�� �ִ� ��ġ��
-//					q.push(make_pair(make_pair(i, j), k));
-//				}
-//				if (graph[i][j][k] == -1) visited[i][j][k] = 1; // -1�̸� ���̴ϱ� visited 1�� ����
-//
-//			}
-//		}
-//	}
-//	
-//
-//	while (!q.empty()) {
-//		int row = q.front().first.first;
-//		int col = q.front().first.second;
-//		int height = q.front().second;
-//
-//		q.pop();
-//
-//		visited[row][col][height] = 1;
-//
-//		for (int d = 0; d < 6; d++) {
-//			int next_x = row + dx[d];
-//			int next_y = col + dy[d];
-//			int next_z = height + dz[d];
-//
-//			if (next_x >= 1 && next_x <= N
-//				&& next_y >= 1 && next_y <= M
-//				&& next_z >= 1 && next_z <= H
-//				&& graph[next_x][next_y][next_z] == 0
-//				&& visited[next_x][next_y][next_z] != 1) {
-//				graph[next_x][next_y][next_z] = graph[row][col][height] + 1;
-//				q.push(make_pair(make_pair(next_x, next_y), next_z));
-//			}
-//		}
-//	}
-//
-//	bool check = true;
-//	int max = 0;
-//	for (int k = 1; k <= H; k++) {
-//		for (int i = 1; i <= N; i++) {
-//			for (int j = 1; j <= M; j++) {
-//				//cout << graph[i][j][k];
-//				if (graph[i][j][k] > max) max = graph[i][j][k];
-//				if (visited[i][j][k] != 1) {
-//					check = false;
-//					cout << -1;
-//					break;
-//				}				
-//			}
-//			if (!check) break;
-//		}
-//		if (!check) break;
-//	}
-//	
-//	answer = max;
-//	if (check) { cout << answer - 1; }
-//}
+#include <iostream>
+#include <queue>
+
+using namespace std;
+
+int graph[101][101][101]; // 이차원 벡터 선언을 너무 많이 할 경우 이렇게 배열로 선언
+int visited[101][101][101];
+
+int M, N, H;
+queue<pair<pair<int, int>, int>> q;
+
+/**
+ * 3차원에서 dx, dy, dz 좌표 표현 방법
+*/
+int dx[] = { 1, -1, 0, 0, 0, 0};
+int dy[] = { 0, 0, 1, -1, 0, 0};
+int dz[] = { 0, 0, 0, 0, 1, -1};
+
+int answer;
+
+int main() {
+	cin >> M >> N >> H;
+	int tomato;
+
+	for (int k = 1; k <= H; k++) {
+		for (int i = 1; i <= N; i++) {
+			for (int j = 1; j <= M; j++) {
+
+				cin >> tomato;
+				graph[i][j][k] = tomato;
+				if (graph[i][j][k] == 1) { // 익은 토마토
+					q.push(make_pair(make_pair(i, j), k));
+                    visited[i][j][k] = 1;
+				}
+				if (graph[i][j][k] == -1) visited[i][j][k] = 1; // -1인 곳은 방문 체크해도 된다
+
+			}
+		}
+	}
+	
+
+	while (!q.empty()) {
+		int row = q.front().first.first;
+		int col = q.front().first.second;
+		int height = q.front().second;
+
+		q.pop();
+
+		for (int d = 0; d < 6; d++) {
+			int next_x = row + dx[d];
+			int next_y = col + dy[d];
+			int next_z = height + dz[d];
+
+            // x, y, z, 각각 범위 확인
+            // 그래프 0인지 확인
+            // 방문하지 않았는지 확인
+			if (next_x >= 1 && next_x <= N
+				&& next_y >= 1 && next_y <= M
+				&& next_z >= 1 && next_z <= H
+				&& graph[next_x][next_y][next_z] == 0
+				&& visited[next_x][next_y][next_z] != 1) {
+				graph[next_x][next_y][next_z] = graph[row][col][height] + 1;
+				q.push(make_pair(make_pair(next_x, next_y), next_z));
+                visited[next_x][next_y][next_z] = 1;
+			}
+		}
+	}
+
+    // 익지 않은 토마토 있는지 확인
+	bool check = true;
+	int max = 0;
+	for (int k = 1; k <= H; k++) {
+		for (int i = 1; i <= N; i++) {
+			for (int j = 1; j <= M; j++) {
+				if (graph[i][j][k] > max) max = graph[i][j][k];
+				if (visited[i][j][k] != 1) {
+					check = false;
+					cout << -1;
+					break;
+				}				
+			}
+			if (!check) break;
+		}
+		if (!check) break;
+	}
+	
+	answer = max;
+	if (check) { cout << answer - 1; }
+}

--- a/BOJ/G5_7576_re.cpp
+++ b/BOJ/G5_7576_re.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std; // 1:15 - 1:41
+
+int N, M;
+
+int dx[4] = {0, 0, 1, -1};
+int dy[4] = {1, -1, 0, 0};
+
+// 1 : 익은 토마토 / 0 : 익지 않은 토마토 / -1 : 토마토 없음
+vector<vector<int>> arr;
+vector<vector<bool>> visited;
+
+typedef struct location {
+    int r, c, cnt;
+} location;
+
+queue<location> q;
+int answer = 0;
+
+int main() {
+    // input
+     cin >> M >> N;
+     arr = vector<vector<int>>(N, vector<int>(M));
+
+     for(int i = 0; i < N; i++) {
+        for(int j = 0; j < M; j++) {
+            cin >> arr[i][j];
+            if(arr[i][j] == 1) {
+                q.push({i, j, 0});
+            }
+        }
+     }
+
+    // bfs
+     while(!q.empty()) {
+        int r = q.front().r;
+        int c = q.front().c;
+        int cnt = q.front().cnt;
+        q.pop();
+
+        if(cnt > answer) answer = cnt;
+
+        for(int d = 0; d < 4; d++) {
+            int rr = r + dx[d];
+            int cc = c + dy[d];
+            if(rr < 0 || rr >= N || cc < 0 || cc >= M) continue;
+            if(arr[rr][cc] != 0) continue;
+
+            q.push({rr, cc, cnt + 1});
+            arr[rr][cc] = cnt + 1;
+        }
+     }
+
+    bool find = true;
+     for(int i = 0; i < N; i++) {
+        for(int j = 0; j < M; j++) {
+            if(arr[i][j] == 0) {
+                find = false;
+                break;
+            }
+        }
+     }
+
+    if(find) cout << answer;
+    else cout << -1;
+
+     return 0;
+}

--- a/BOJ/S1_1697_re.cpp
+++ b/BOJ/S1_1697_re.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <queue>
+#include <set>
+#include <algorithm>
+
+using namespace std; // 2:00 - 2:17
+
+int N, K; // 수빈, 동생
+int answer =  0;
+int max_value;
+set<int> s;
+
+int main() {
+    // input
+    cin >> N >> K;
+    queue<pair<int, int>> q;
+    max_value = max(N, K) + 2;
+
+    q.push({N, 0});
+    s.insert(N);
+
+    while(!q.empty()) {
+        int num = q.front().first;
+        int cnt = q.front().second;
+        q.pop();
+
+        // stop condition
+        if(num == K) {
+            answer  = cnt;
+            break;
+        }
+
+        if(num + 1 >= 0 && num + 1 <= max_value && s.find(num + 1) == s.end()) { 
+            q.push({num + 1, cnt + 1});
+            s.insert(num + 1);
+        }
+        if(num - 1 >= 0 && num - 1 <= max_value && s.find(num - 1) == s.end()) {
+            q.push({num - 1, cnt + 1});
+            s.insert(num - 1);
+        }
+        if(2 * num >= 0 && num * 2 <= max_value && s.find(num * 2) == s.end()) {
+            q.push({2 * num, cnt + 1});
+            s.insert(2 * num);
+        }
+    }
+
+    cout << answer;
+    return 0;
+}

--- a/BOJ/S1_1926.cpp
+++ b/BOJ/S1_1926.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <algorithm>
+
+using namespace std;
+
+// 12:22
+int N, M; // 세로, 가로
+vector<vector<int>> arr;
+vector<vector<bool>> visited;
+vector<int> correct;
+
+int dx[4] = {0, 0, 1, -1};
+int dy[4] = {1, -1, 0, 0};
+
+typedef struct loc {
+    int r, c;
+} loc;
+
+queue<loc> q;
+int current_width = 0;
+
+int bfs() {
+    int max_cnt = 0;
+    while(!q.empty()) {
+        int r = q.front().r;
+        int c = q.front().c;
+        max_cnt++;
+        q.pop();
+
+        for(int d = 0; d < 4; d++) {
+            int rr = r + dx[d];
+            int cc = c + dy[d];
+
+            if(rr < 0 || rr >= N || cc < 0 || cc >= M 
+            || visited[rr][cc] || arr[rr][cc] == 0) continue;
+            visited[rr][cc] = true;
+            q.push({rr, cc});
+        }
+    }
+
+    return max_cnt;
+}
+
+int main() {
+    // input
+    cin >> N >> M;
+    arr = vector<vector<int>>(N, vector<int>(M));
+    visited = vector<vector<bool>>(N, vector<bool>(M, false));
+
+    for(int i = 0; i < N; i++) {
+        for(int j = 0; j < M; j++) {
+            cin >> arr[i][j];
+        }
+    }
+
+    // bfs
+    for(int i = 0; i < N; i++) {
+        for(int j = 0; j < M; j++) {
+            if(!visited[i][j] && arr[i][j] == 1) {
+                loc l; l.r = i; l.c = j; 
+                visited[i][j] = true;
+                q.push(l);
+                correct.push_back(bfs());
+            }
+        }
+    }
+
+    sort(correct.begin(), correct.end());
+    if(correct.size() == 0) cout << 0 << "\n" << 0;
+    else cout << correct.size() << "\n" << correct.back();
+    
+    return 0;
+}

--- a/BOJ/S1_2178_re.cpp
+++ b/BOJ/S1_2178_re.cpp
@@ -1,0 +1,66 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std; // 12:46 - 12:59
+
+// 1,1에서 N, M까지 이동할 때 지나는 최소의 칸 수
+int N, M;
+vector<vector<int>> arr;
+vector<vector<bool>> visited;
+
+typedef struct location {
+    int r, c, cnt;
+} location;
+
+queue<location> q;
+int answer = 0;
+
+int dx[4] = {0, 0, 1, -1};
+int dy[4] = {1, -1, 0, 0};
+
+int main () {
+    // input
+    cin >> N >> M;
+    arr = vector<vector<int>>(N, vector<int>(M));
+    visited = vector<vector<bool>>(N, vector<bool>(M, false));
+
+    for(int i = 0; i < N; i++) {
+        string str;
+        cin >> str;
+        for(int j = 0; j < M; j++) {
+            arr[i][j] = str[j] - '0';
+        }
+    }
+
+    // bfs
+    q.push({0, 0, 1});
+    visited[0][0] = true;
+
+    while(!q.empty()) {
+        int r = q.front().r;
+        int c = q.front().c;
+        int cnt = q.front().cnt;
+        q.pop();
+
+        // stop condition
+        if(r == N - 1 && c == M - 1) {
+            answer = cnt;
+            break;
+        }
+
+        for(int d = 0; d < 4; d++) {
+            int rr = r + dx[d];
+            int cc = c + dy[d];
+
+            if(rr < 0 || rr >= N || cc < 0 || cc >= M
+            || arr[rr][cc] == 0 || visited[rr][cc]) continue;
+            q.push({rr, cc, cnt + 1});
+            visited[rr][cc] = true;
+        }
+    }
+    
+    cout << answer;
+
+    return 0;
+}

--- a/BOJ/S2_11725_re.cpp
+++ b/BOJ/S2_11725_re.cpp
@@ -1,0 +1,50 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+
+using namespace std; // 9:50
+
+int N;
+vector<int> graph[100001];
+vector<int> visited;
+int parent[100001];
+
+int main() {
+    // input
+    cin >> N;
+    visited.resize(N + 1);
+
+    for(int i = 0; i < N - 1; i++) {
+        int u, v;
+        cin >> u >> v;
+        graph[u].push_back(v);
+        graph[v].push_back(u);
+    }
+
+    parent[1] = 0; // 1번이 루트이므로 부모가 0
+
+    queue<pair<int, int>> q;
+    q.push({0, 1}); // parent, child
+    visited[1] = true;
+
+    while(!q.empty()) {
+        int p = q.front().first;
+        int child = q.front().second;
+        q.pop();
+
+        parent[child] = p;
+
+        for(int next : graph[child]) {
+            if(visited[next]) continue;
+            q.push({child, next});
+            visited[next] = true;
+        }
+    }
+
+    for(int i = 2; i <= N; i++) {
+        cout << parent[i] << "\n";
+    }
+
+    return 0;
+
+}

--- a/BOJ/S3_1463.cpp
+++ b/BOJ/S3_1463.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std; // 5:16
+
+int N;
+vector<int> dp;
+
+int main() {
+    // input
+    cin >> N;
+    dp.resize(N + 1);
+
+    dp[1] = 0;
+    for(int i = 2; i <= N; i++) {
+        dp[i] = dp[i - 1] + 1;
+        if(i%2 == 0) dp[i] = min(dp[i], dp[i/2] + 1);
+        if(i%3 == 0) dp[i] = min(dp[i], dp[i/3] + 1);
+    }
+
+    cout << dp[N];
+    return 0;
+}

--- a/BOJ/S3_2579_re.cpp
+++ b/BOJ/S3_2579_re.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int N;
+
+int main() {
+    // input
+    cin >> N; 
+    vector<int> arr(N);
+    for(int i = 0; i < N; i++) 
+        cin >> arr[i];
+
+    // dp
+    vector<vector<int>> dp(N, vector<int>(2, 0));
+
+    if(N == 1) {
+        cout << arr[0];
+        return 0;
+    }
+    if(N == 2) {
+        cout << arr[0] + arr[1];
+        return 0;
+    }
+
+    dp[0][0] = arr[0]; dp[0][1] = arr[0];
+    dp[1][0] = arr[1]; dp[1][1] = arr[0] + arr[1];
+
+    for(int i = 2; i < N; i++) {
+        dp[i][0] = max(dp[i - 2][1], dp[i - 2][0]) + arr[i];
+        dp[i][1] = dp[i - 1][0] + arr[i];
+    }
+    // for(int i = 0; i < N; i++) {
+    //     cout << dp[i][0] << " " << dp[i][1] << "\n";
+    // }
+
+    cout << max(dp[N - 1][0], dp[N - 1][1]);
+    return 0;
+}


### PR DESCRIPTION
## S1 그림

이 문제를 보고 dfs로 접근했는데, 깊이 타고 들어가다가 더이상 갈 수 없는 지점을 만났을 때 return 해서 다음 지점에 방문해야 하는데, 그 부분을 체크하지 않았었다. 그래서 bfs로 다시 접근해서 풀었다. 큐에 push할 때 방문 체크를 하는 것에 주의하자! (바킹독의 BFS 리뉴얼 블로그를 봤는데 놓치기 쉬운 부분들 정리를 잘해주시는 것 같다)

- **q.push 직후 바로 visited = true 필수!**

<br>

## S1 미로 탐색

구조체를 이용해서 이동할 때마다 cnt 값을 +1 하는 형태로 계산했는데, 그럴 필요 없었다. 따로 dist 기록용 벡터를 두고, cnt를 각 칸에 기록하면서 진행하는 방식이 훨씬 메모리를 덜 사용하는 방식같다!!

- **특정 지점부터 다른 지점까지 거리를 측정하는 경우, dist 배열을 이용해서 해당 칸까지의 거리 기록!**

<br>

## G5 토마토

그림 문제는 기본 BFS 문제이고, 미로 탐색은 거리를 측정 하는 도구로서의 BFS이다. (최단 거리 문제를 구하는 방법 중 BFS를 이용하는 방법도 있다.) 그리고 이 토마토 문제는 **시작점이 여러 개인 BFS 문제이다.**

- 시작점이 여럿인 경우, 초기 q에 시작점을 전부 push 하고 시작한다!